### PR TITLE
Fix code scanning alert no. 46: Unsafe HTML constructed from library input

### DIFF
--- a/src/ng2-atomspace-visualizer/visualizer/visualizer.component.ts
+++ b/src/ng2-atomspace-visualizer/visualizer/visualizer.component.ts
@@ -645,14 +645,40 @@ export class VisualizerComponent implements AfterViewInit, OnInit, OnDestroy, On
     const strUnfiltered = this._translate.instant('Unfiltered');
     const strFilterOnSelection = this._translate.instant('FilterOnSelection');
     $('#filtermenu').empty();
-    $('#filtermenu').append('<div class=\'header\'><i class=\'tags icon\'></i><span>' + strFilterOnSelection +
-      '</span></div><div class=\'divider\'></div>');
-    this.nodeTypes.forEach(type => { $('#filtermenu').append('<div class=\'item\'><span>' + type + '</span></div>'); });
+    const headerDiv = document.createElement('div');
+    headerDiv.className = 'header';
+    const icon = document.createElement('i');
+    icon.className = 'tags icon';
+    const spanFilterOnSelection = document.createElement('span');
+    spanFilterOnSelection.textContent = strFilterOnSelection;
+    headerDiv.appendChild(icon);
+    headerDiv.appendChild(spanFilterOnSelection);
+    $('#filtermenu').append(headerDiv);
     $('#filtermenu').append('<div class=\'divider\'></div>');
-    this.linkTypes.forEach(type => { $('#filtermenu').append('<div class=\'item\'><span>' + type + '</span></div>'); });
-    // $('#filtermenu').append('<div class=\'divider\'></div><div class=\'item\'><span>' +
-    //   '<i class=\'remove icon\' id=\'removeicon\'></i>' + strUnfiltered + '</span></div>');
-    $('#filtermenu').append('<div class=\'divider\'></div><div class=\'item\'><span>' + strUnfiltered + '</span></div>');
+    this.nodeTypes.forEach(type => {
+      const itemDiv = document.createElement('div');
+      itemDiv.className = 'item';
+      const spanType = document.createElement('span');
+      spanType.textContent = type;
+      itemDiv.appendChild(spanType);
+      $('#filtermenu').append(itemDiv);
+    });
+    $('#filtermenu').append('<div class=\'divider\'></div>');
+    this.linkTypes.forEach(type => {
+      const itemDiv = document.createElement('div');
+      itemDiv.className = 'item';
+      const spanType = document.createElement('span');
+      spanType.textContent = type;
+      itemDiv.appendChild(spanType);
+      $('#filtermenu').append(itemDiv);
+    });
+    $('#filtermenu').append('<div class=\'divider\'></div>');
+    const unfilteredDiv = document.createElement('div');
+    unfilteredDiv.className = 'item';
+    const spanUnfiltered = document.createElement('span');
+    spanUnfiltered.textContent = strUnfiltered;
+    unfilteredDiv.appendChild(spanUnfiltered);
+    $('#filtermenu').append(unfilteredDiv);
 
     filterMenuInitialized = true;
   }


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/46](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/46)

To fix the problem, we should avoid using `innerHTML` to insert potentially unsafe content into the DOM. Instead, we can use safer methods such as `textContent` or create DOM elements programmatically and append them. This ensures that any HTML tags in the content are treated as plain text and not executed.

In this specific case, we will:
1. Replace the use of `innerHTML` with `textContent` for the `strUnfiltered` variable.
2. Create and append DOM elements programmatically for the other parts of the filter menu to ensure all content is safely inserted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
