### PR TITLE
Fix code scanning alert no. 44: Unsafe HTML constructed from library input

### DIFF
--- a/src/assets/semantic/components/video.js
+++ b/src/assets/semantic/components/video.js
@@ -198,14 +198,14 @@ $.fn.video = function(parameters) {
               }
               if(source == 'vimeo') {
                 html = ''
-                  + '<iframe src="//player.vimeo.com/video/' + id + '?=' + DOMPurify.sanitize(module.generate.url(source)) + '"'
+                  + '<iframe src="//player.vimeo.com/video/' + DOMPurify.sanitize(id) + '?=' + DOMPurify.sanitize(module.generate.url(source)) + '"'
                   + ' width="100%" height="100%"'
                   + ' frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>'
                 ;
               }
               else if(source == 'youtube') {
                 html = ''
-                  + '<iframe src="//www.youtube.com/embed/' + id + '?=' + DOMPurify.sanitize(module.generate.url(source)) + '"'
+                  + '<iframe src="//www.youtube.com/embed/' + DOMPurify.sanitize(id) + '?=' + DOMPurify.sanitize(module.generate.url(source)) + '"'
                   + ' width="100%" height="100%"'
                   + ' frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>'
                 ;

--- a/src/assets/semantic/components/video.js
+++ b/src/assets/semantic/components/video.js
@@ -9,6 +9,7 @@
  *
  */
 
+const DOMPurify = require('dompurify');
 ;(function ($, window, document, undefined) {
 
 "use strict";
@@ -197,14 +198,14 @@ $.fn.video = function(parameters) {
               }
               if(source == 'vimeo') {
                 html = ''
-                  + '<iframe src="//player.vimeo.com/video/' + id + '?=' + module.generate.url(source) + '"'
+                  + '<iframe src="//player.vimeo.com/video/' + id + '?=' + DOMPurify.sanitize(module.generate.url(source)) + '"'
                   + ' width="100%" height="100%"'
                   + ' frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>'
                 ;
               }
               else if(source == 'youtube') {
                 html = ''
-                  + '<iframe src="//www.youtube.com/embed/' + id + '?=' + module.generate.url(source) + '"'
+                  + '<iframe src="//www.youtube.com/embed/' + id + '?=' + DOMPurify.sanitize(module.generate.url(source)) + '"'
                   + ' width="100%" height="100%"'
                   + ' frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>'
                 ;

--- a/src/assets/semantic/package.json
+++ b/src/assets/semantic/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/Semantic-Org/Semantic-UI/issues"
   },
   "dependencies": {
-    "jquery": "x.*"
+    "jquery": "x.*",
+    "dompurify": "^3.1.7"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/44](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/44)

To fix the problem, we need to ensure that any user-supplied input used in HTML construction is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue is to use a safe API or sanitize the input before using it in the HTML context.

1. **Sanitize the input:** Use an HTML sanitizer library to clean the input before constructing the HTML.
2. **Use safe APIs:** Instead of directly setting `innerHTML`, use methods like `textContent` or `createElement` to safely construct the HTML.

In this case, we will use the `DOMPurify` library to sanitize the input before using it in the HTML construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
