### PR TITLE
Fix code scanning alert no. 40: Unsafe jQuery plugin

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -21409,7 +21409,7 @@ $.fn.visibility = function(parameters) {
         $window         = $(window),
 
         $module         = $(this),
-        $context        = $(settings.context),
+        $context        = $.find(settings.context),
 
         $placeholder,
 


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/40](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/40)

To fix the problem, we need to ensure that the `settings.context` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing `settings.context` to the jQuery constructor. This change will prevent the possibility of interpreting the input as HTML, thus mitigating the XSS risk.

1. Identify the line where `settings.context` is used in a jQuery selector.
2. Replace the direct use of `settings.context` with `jQuery.find(settings.context)` to ensure it is treated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
