### PR TITLE
Fix code scanning alert no. 17: Unsafe jQuery plugin

### DIFF
--- a/src/assets/bootstrap/js/bootstrap.js
+++ b/src/assets/bootstrap/js/bootstrap.js
@@ -1275,8 +1275,9 @@ if (typeof jQuery === 'undefined') {
   }
 
   Tooltip.prototype.validateContainer = function (container) {
-    if (typeof container === 'string' && $(container).length) {
-      return container;
+    if (typeof container === 'string') {
+      var safeContainer = $.find(container);
+      return safeContainer.length ? safeContainer : false;
     } else if (container instanceof jQuery || container instanceof HTMLElement) {
       return container;
     } else {

--- a/src/assets/bootstrap/js/bootstrap.js
+++ b/src/assets/bootstrap/js/bootstrap.js
@@ -1274,6 +1274,16 @@ if (typeof jQuery === 'undefined') {
     this.init('tooltip', element, options)
   }
 
+  Tooltip.prototype.validateContainer = function (container) {
+    if (typeof container === 'string' && $(container).length) {
+      return container;
+    } else if (container instanceof jQuery || container instanceof HTMLElement) {
+      return container;
+    } else {
+      return false; // Default safe value
+    }
+  }
+
   Tooltip.VERSION  = '3.3.5'
 
   Tooltip.TRANSITION_DURATION = 150
@@ -1299,6 +1309,7 @@ if (typeof jQuery === 'undefined') {
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
+    this.options.container = this.validateContainer(this.options.container)
     this.$viewport = this.options.viewport && $($.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport))
     this.inState   = { click: false, hover: false, focus: false }
 


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/17](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/17)

To fix the problem, we need to ensure that the `container` option is properly sanitized or validated before it is used. One way to do this is to check if the `container` is a valid jQuery selector or a DOM element. If it is not, we can either ignore it or set it to a default safe value.

- We will add a validation step in the `Tooltip.prototype.init` method to ensure `this.options.container` is a valid selector or DOM element.
- If the validation fails, we will set `this.options.container` to a default safe value, such as `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
