### PR TITLE
Fix code scanning alert no. 5: Overly permissive regular expression range

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -20620,8 +20620,8 @@ $.api.settings = {
   },
 
   regExp  : {
-    required : /\{\$*[A-z0-9]+\}/g,
-    optional : /\{\/\$*[A-z0-9]+\}/g,
+    required : /\{\$*[A-Za-z0-9]+\}/g,
+    optional : /\{\/\$*[A-Za-z0-9]+\}/g,
   },
 
   className: {


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/5](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/5)

To fix the problem, we need to update the regular expression to use the correct character range. Specifically, we should replace `A-z` with `A-Za-z` to ensure that only alphabetic characters (both uppercase and lowercase) are matched, along with digits.

- Update the regular expression on line 20623 to use `A-Za-z0-9` instead of `A-z0-9`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
