### PR TITLE
Fix code scanning alert no. 3: Overly permissive regular expression range

### DIFF
--- a/src/assets/semantic/components/progress.js
+++ b/src/assets/semantic/components/progress.js
@@ -894,7 +894,7 @@ $.fn.progress.settings = {
   },
 
   regExp: {
-    variable: /\{\$*[A-z0-9]+\}/g
+    variable: /\{\$*[A-Za-z0-9]+\}/g
   },
 
   metadata: {


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/3](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/3)

To fix the problem, we need to replace the overly permissive range `[A-z]` with a more precise range that matches only the uppercase and lowercase letters. The correct ranges are `[A-Z]` for uppercase letters and `[a-z]` for lowercase letters. We can combine these ranges to form `[A-Za-z]`.

- **General fix:** Replace the overly permissive range `[A-z]` with `[A-Za-z]` in the regular expression.
- **Detailed fix:** In the file `src/assets/semantic/components/progress.js`, on line 897, update the regular expression to use `[A-Za-z0-9]` instead of `[A-z0-9]`.
- **Specific changes:** Modify the regular expression in the `regExp` object to ensure it matches only the intended characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
