### PR TITLE
Fix code scanning alert no. 39: Unsafe jQuery plugin

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -16535,7 +16535,7 @@ $.fn.sticky = function(parameters) {
 
         $module               = $(this),
         $window               = $(window),
-        $scroll               = $(settings.scrollContext),
+        $scroll               = $.find(settings.scrollContext),
         $container,
         $context,
 


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/39](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/39)

To fix the problem, we need to ensure that `settings.scrollContext` is always interpreted as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `jQuery` to select the element. This change ensures that `settings.scrollContext` is always treated as a CSS selector, mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
