### PR TITLE
Fix code scanning alert no. 38: Unsafe jQuery plugin

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -15743,7 +15743,7 @@ $.fn.sidebar = function(parameters) {
 
         refresh: function() {
           module.verbose('Refreshing selector cache');
-          $context  = $(settings.context);
+          $context  = $.find(settings.context);
           $sidebars = $context.children(selector.sidebar);
           $pusher   = $context.children(selector.pusher);
           $fixed    = $context.children(selector.fixed);


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/38](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/38)

To fix the problem, we need to ensure that the `settings.context` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing `settings.context` to the jQuery selector. This change will prevent the evaluation of `settings.context` as HTML, mitigating the XSS risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
