### PR TITLE
Fix code scanning alert no. 34: Unsafe jQuery plugin

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -10223,7 +10223,7 @@ $.fn.popup = function(parameters) {
 
         $module            = $(this),
         $context           = $(settings.context),
-        $scrollContext     = $(settings.scrollContext),
+        $scrollContext     = $(document).find(settings.scrollContext),
         $boundary          = $(settings.boundary),
         $target            = (settings.target)
           ? $(settings.target)


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/34](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/34)

To fix the issue, we need to ensure that the `settings.scrollContext` is always treated as a CSS selector and not as HTML. This can be achieved by using jQuery's `.find()` method instead of `$()` for selecting elements based on the `scrollContext`.

- **General Fix:** Use jQuery's `.find()` method to interpret `settings.scrollContext` as a CSS selector.
- **Detailed Fix:** Replace the usage of `$(settings.scrollContext)` with `$(document).find(settings.scrollContext)` to ensure it is always treated as a CSS selector.
- **Files/Regions/Lines to Change:** The change needs to be made in the file `src/assets/semantic/semantic.js` at line 10226.
- **Required Changes:** No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
