### PR TITLE
Fix code scanning alert no. 4: Overly permissive regular expression range

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -12537,7 +12537,7 @@ $.fn.progress.settings = {
   },
 
   regExp: {
-    variable: /\{\$*[A-z0-9]+\}/g
+    variable: /\{\$*[A-Za-z0-9]+\}/g
   },
 
   metadata: {


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/4](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/4)

To fix the problem, we need to adjust the regular expression to correctly match only the uppercase and lowercase letters, along with digits. The correct range should be `A-Za-z` instead of `A-z`.

- **General Fix:** Replace the overly permissive range `A-z` with the correct range `A-Za-z`.
- **Detailed Fix:** In the file `src/assets/semantic/semantic.js`, on line 12540, update the regular expression to use `A-Za-z0-9` instead of `A-z0-9`.
- **Specific Changes:** Modify the regular expression definition within the `regExp` object.
- **Requirements:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
