### PR TITLE
Fix code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/src/assets/semantic/components/api.js
+++ b/src/assets/semantic/components/api.js
@@ -1142,8 +1142,8 @@ $.api.settings = {
   },
 
   regExp  : {
-    required : /\{\$*[A-z0-9]+\}/g,
-    optional : /\{\/\$*[A-z0-9]+\}/g,
+    required : /\{\$*[A-Za-z0-9]+\}/g,
+    optional : /\{\/\$*[A-Za-z0-9]+\}/g,
   },
 
   className: {


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/1](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/1)

To fix the problem, we need to replace the overly permissive range `A-z` with a more precise range that matches only the intended characters. In this case, we should use `A-Za-z` to match all uppercase and lowercase letters without including special characters.

- **General Fix:** Replace the range `A-z` with `A-Za-z` in the regular expression.
- **Detailed Fix:** Update the regular expressions on lines 1145 and 1146 to use `A-Za-z` instead of `A-z`.
- **Specific Changes:** Modify the file `src/assets/semantic/components/api.js` on lines 1145 and 1146.
- **Requirements:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
