### PR TITLE
Fix code scanning alert no. 37: Unsafe jQuery plugin

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -15511,7 +15511,7 @@ $.fn.sidebar = function(parameters) {
         moduleNamespace = 'module-' + namespace,
 
         $module         = $(this),
-        $context        = $(settings.context),
+        $context        = $.find(settings.context),
 
         $sidebars       = $module.children(selector.sidebar),
         $fixed          = $context.children(selector.fixed),


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/37](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/37)

To fix the problem, we need to ensure that the `context` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of directly passing the `context` to the jQuery selector. This approach ensures that the input is always interpreted as a CSS selector.

- **General Fix**: Use `jQuery.find` to interpret `context` as a CSS selector.
- **Detailed Fix**: Modify the code to use `jQuery.find` for the `context` parameter.
- **Files/Regions/Lines to Change**: The changes will be made in the file `src/assets/semantic/semantic.js` around line 15514.
- **Needed Changes**: Update the jQuery selector to use `jQuery.find`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
