### PR TITLE
Fix code scanning alert no. 36: Unsafe jQuery plugin

### DIFF
--- a/src/assets/semantic/semantic.js
+++ b/src/assets/semantic/semantic.js
@@ -10526,7 +10526,7 @@ $.fn.popup = function(parameters) {
         },
 
         hideAll: function() {
-          $(selector.popup)
+          $document.find(selector.popup)
             .filter('.' + className.visible)
             .each(function() {
               $(this)


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/36](https://github.com/rez-trueagi-io/atomspace-explorer/security/code-scanning/36)

To fix the problem, we need to ensure that the `selector` used in `$(selector.popup)` is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of directly passing the selector to `jQuery`. This change ensures that the selector is interpreted correctly and safely.

1. Identify the line where `selector.popup` is used.
2. Replace the direct jQuery call with a safe method that interprets the selector as a CSS selector.
3. Ensure that the rest of the functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
